### PR TITLE
Added Google recaptcha for register form

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -29,3 +29,5 @@ DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
 # Delivery is disabled by default via "null://localhost"
 MAILER_URL=null://localhost
 ###< symfony/swiftmailer-bundle ###
+
+GOOGLE_RECAPTCHA_KEY=~

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -5,3 +5,5 @@ twig:
         - 'bootstrap_4_layout.html.twig'
         - 'frontend/form/layout.html.twig'
         - 'frontend/form/fields.html.twig'
+    globals:
+        google_recaptcha_key: '%env(GOOGLE_RECAPTCHA_KEY)%'

--- a/templates/frontend/_modules/_form/_register.html.twig
+++ b/templates/frontend/_modules/_form/_register.html.twig
@@ -25,5 +25,6 @@
         message notifications from Cottect and can opt out at any time.
     </small>
 </div>
+<div class="g-recaptcha" data-sitekey="{{ google_recaptcha_key }}"></div>
 <button type="submit" class="btn btn-primary">{{ 'action.register'|trans }}</button>
 {{ form_end(form) }}

--- a/templates/frontend/user/register.html.twig
+++ b/templates/frontend/user/register.html.twig
@@ -24,5 +24,6 @@
 
 {% block javascripts %}
     {{ parent() }}
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <script src="{{ asset('build/js/register.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Based on issue #15. 
You need to add a Google Recaptcha API key to your .env file in order to activate it.
Let me know if you have any suggestions or questions